### PR TITLE
Strip SSH user from datadog links

### DIFF
--- a/src/root/build.tt
+++ b/src/root/build.tt
@@ -57,7 +57,7 @@ END;
             </td>
             <td>
               [% IF step.machine.search('hetzner') %]
-                <a href="https://app.datadoghq.com/dash/host_name/[% step.machine %]?from_ts=[% step.starttime*1000 %][% step.stoptime > 0 ? "&to_ts=${step.stoptime}000&live=false": '&live=true' %]">
+                <a href="https://app.datadoghq.com/dash/host_name/[% stripSSHUser(step.machine) %]?from_ts=[% step.starttime*1000 %][% step.stoptime > 0 ? "&to_ts=${step.stoptime}000&live=false": '&live=true' %]">
               [% END %]
               [% IF step.busy != 0 || ((step.machine || step.starttime) && (step.status == 0 || step.status == 1 || step.status == 3 || step.status == 4 || step.status == 7));
               INCLUDE renderMachineName machine=step.machine; ELSE; "<em>n/a</em>"; END %]


### PR DESCRIPTION
Remote build machines are saved in the database with the ssh users that used to connect to them, we need to strip them since we only need the machine name in the Datadog link.   